### PR TITLE
Fix connection failure detection

### DIFF
--- a/arduinoethernetshieldstream.ino
+++ b/arduinoethernetshieldstream.ino
@@ -124,7 +124,7 @@ bool postBucket() {
   client.stop();
 
   // if there's a successful connection:
-  if (client.connect(ISDestURL, 80)) {
+  if (client.connect(ISDestURL, 80) > 0) {
     Serial.println("connecting...");
     // send the HTTP PUT request:
     // Build HTTP request.
@@ -163,7 +163,7 @@ bool postData() {
   client.stop();
 
   // if there's a successful connection:
-  if (client.connect(ISDestURL, 80)) {
+  if (client.connect(ISDestURL, 80) > 0) {
     Serial.println("connecting...");
     // send the HTTP PUT request:
     // Build HTTP request.


### PR DESCRIPTION
client.connect returns an int (1,-1,-2,-3,-4) indicating connection status. The postBucket and postData functions will always evaluate true because it is always returning a non-zero. Changing to > 0 fixes this issue and is able to detect success or failure. 

SUCCESS 1
TIMED_OUT -1
INVALID_SERVER -2
TRUNCATED -3
INVALID_RESPONSE -4